### PR TITLE
Provide an edit link on all articles

### DIFF
--- a/_includes/edit-post.html
+++ b/_includes/edit-post.html
@@ -1,0 +1,5 @@
+<p class="edit-post">
+(You can <a href="{{ site.github_repo }}/edit/build/{{ post.path }}">suggest changes</a>
+to this post.)
+</p>
+

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,4 +6,5 @@
     -->
     <h2><a href="#">{{ post.title }}</a></h2>
     <!-- <span class="byline">A free, fully responsive HTML5 site template by AJ for HTML5 UP</span> -->
+    {% include edit-post.html %}
 </header>

--- a/css/pjf.css
+++ b/css/pjf.css
@@ -102,6 +102,20 @@ img.me {
     padding-left: 1em;
 }
 
+
+/* Edit this post */
+
+.edit-post {
+    text-align: right;
+    font-size: smaller;
+    opacity: .5;
+    float: right;
+}
+
+.edit-post:hover {
+    opacity: 1.0;
+}
+
 /* AddThis */
 
 div.addthis_container {


### PR DESCRIPTION
An initial stab at addressing issue #11, "Provide edit links on all articles".

I started with "(edit)" but moved to a more inviting link text that would hopefully make sense even in plain-text contexts.

The visual design is trying to be discreet -- it could do with some work, especially at very small viewport widths.
