### PR TITLE
Fancybox Enhancments

### DIFF
--- a/_includes/fancybox.html
+++ b/_includes/fancybox.html
@@ -1,3 +1,8 @@
 <!-- TODO: Only load on fancybox pages -->
 <link rel="stylesheet" href="/fancybox/source/jquery.fancybox.css?v=2.1.5" type="text/css" media="screen" />
 <script type="text/javascript" src="/fancybox/source/jquery.fancybox.pack.js?v=2.1.5"></script>
+<script>
+  $(window).load(function() {
+    $(".fancybox_gallery").fancybox();
+  });
+</script>

--- a/_plugins/image_tag.rb
+++ b/_plugins/image_tag.rb
@@ -90,6 +90,8 @@ module Jekyll
 
       if tag_name == 'fancybox'
         @fancybox = true
+      elsif tag_name == 'gallery'
+        @gallery = true
       end
 
     end
@@ -98,14 +100,18 @@ module Jekyll
       source = @class ? "<figure class='#{@class}'>" : "<figure>"
       if @fancybox
         source += "<a class=\"fancybox\" rel=\"group\" href=\"#{@url}\">"
-        if @alt 
-          source += "<img src=\"#{@alt}\"></a>"
-        else
-          source += "<img src=\"#{@url}\"></a>"
-        end
+      elsif @gallery
+        source += "<a class=\"fancybox fancybox_gallery\" rel=\"group\" href=\"#{@url}\">"
       else
         source += "<img src=\"#{@url}\">"
       end
+      
+      if (@fancybox || @gallery) && @alt 
+        source += "<img src=\"#{@alt}\"></a>"
+      else
+        source += "<img src=\"#{@url}\"></a>"
+      end
+
       source += "<figcaption>#{@caption}</figcaption>" if @caption
       source += "</figure>"
 
@@ -116,3 +122,4 @@ end
 
 Liquid::Template.register_tag('image',    Jekyll::ImageTag)
 Liquid::Template.register_tag('fancybox', Jekyll::ImageTag)
+Liquid::Template.register_tag('gallery', Jekyll::ImageTag)


### PR DESCRIPTION
As promised. Fancybox galleries can be utilised by using the tag gallery instead

```
{% gallery .... %}
```

And an alternate source can be provided now to have thumbnails (G+ images makes this trivial, width + height is controllable via the url).

```
{% gallery https://lh5.googleusercontent.com/-RxG-kI3AMXA/UvtjLu7eoqI/AAAAAAAAIq0/TJ6J8gj_MCo/w1324-h1023-no/IMG_0293-edit.JPG "Dropout Repair" https://lh5.googleusercontent.com/-RxG-kI3AMXA/UvtjLu7eoqI/AAAAAAAAIq0/TJ6J8gj_MCo/w250/IMG_0293-edit.JPG %}
```

Working example here:
http://www.techman83.me/personal/2014/02/12/refit_bb.html
